### PR TITLE
Fix compilation with boost 1.58

### DIFF
--- a/qi/detail/futurebarrier.hpp
+++ b/qi/detail/futurebarrier.hpp
@@ -191,7 +191,7 @@ public:
       throw std::runtime_error("Adding future to closed barrier");
 
     ++(_p->_count);
-    fut.connect(boost::bind<void>(&detail::FutureBarrierPrivate<T>::onFutureFinish, _p));
+    fut.connect(boost::bind(&detail::FutureBarrierPrivate<T>::onFutureFinish, _p));
     _p->_futures.push_back(fut);
   }
 

--- a/src/eventloop.cpp
+++ b/src/eventloop.cpp
@@ -352,7 +352,7 @@ namespace qi {
 
 
       ++_totalTask;
-      _io.post(boost::bind<void>(&EventLoopAsio::invoke_maybe, this, cb, id, p, erc));
+      _io.post(boost::bind(&EventLoopAsio::invoke_maybe, this, cb, id, p, erc));
     }
     else
       asyncCall(delay, cb);
@@ -379,7 +379,7 @@ namespace qi {
       return prom.future();
     }
     Promise<void> prom(PromiseNoop<void>);
-    _io.post(boost::bind<void>(&EventLoopAsio::invoke_maybe, this, cb, id, prom,erc));
+    _io.post(boost::bind(&EventLoopAsio::invoke_maybe, this, cb, id, prom,erc));
     return prom.future();
   }
 
@@ -597,7 +597,7 @@ namespace qi {
     ctx->target = this;
     ctx->helper = helper;
     ctx->maxDelay = maxDelay;
-    ctx->promise = Promise<void>(boost::bind<void>(&monitor_cancel, _1, ctx));
+    ctx->promise = Promise<void>(boost::bind(&monitor_cancel, _1, ctx));
     ctx->isFired = false;
     ctx->ending = false;
     monitor_ping(ctx);

--- a/src/messaging/objectregistrar.cpp
+++ b/src/messaging/objectregistrar.cpp
@@ -158,7 +158,7 @@ namespace qi {
     qi::Promise<unsigned int> prom;
     qi::Future<unsigned int>  future;
     future = _sdClient->registerService(si);
-    future.connect(boost::bind<void>(&ObjectRegistrar::onFutureFinished, this, _1, id, prom));
+    future.connect(boost::bind(&ObjectRegistrar::onFutureFinished, this, _1, id, prom));
 
     return prom.future();
   };

--- a/src/messaging/remoteobject.cpp
+++ b/src/messaging/remoteobject.cpp
@@ -99,7 +99,7 @@ namespace qi {
       // to a 'parent' object.
       _linkMessageDispatcher = _socket->messagePendingConnect(_service,
         TransportSocket::ALL_OBJECTS,
-        boost::bind<void>(&RemoteObject::onMessagePending, this, _1));
+        boost::bind(&RemoteObject::onMessagePending, this, _1));
       _linkDisconnected      = _socket->disconnected.connect (
          &RemoteObject::onSocketDisconnected, this, _1);
     }
@@ -131,7 +131,7 @@ namespace qi {
     qi::Promise<void> prom(qi::FutureCallbackType_Sync);
     qi::Future<qi::MetaObject> fut =
       _self.async<qi::MetaObject>("metaObject", 0U);
-    fut.connect(boost::bind<void>(&RemoteObject::onMetaObject, this, _1, prom));
+    fut.connect(boost::bind(&RemoteObject::onMetaObject, this, _1, prom));
     return prom.future();
   }
 

--- a/src/messaging/servicedirectoryclient.cpp
+++ b/src/messaging/servicedirectoryclient.cpp
@@ -2,6 +2,8 @@
 **  Copyright (C) 2012 Aldebaran Robotics
 **  See COPYING for the license
 */
+
+#include <boost/version.hpp>
 #include "servicedirectoryclient.hpp"
 #include <qi/type/objecttypebuilder.hpp>
 #include "servicedirectory_p.hpp"
@@ -110,7 +112,12 @@ namespace qi {
       return;
     }
 
+#if BOOST_VERSION < 105800
     const Message& msg = boost::get<const Message&>(data);
+#else
+    const Message& msg = boost::relaxed_get<const Message&>(data);
+#endif
+
     unsigned int function = msg.function();
     bool failure = msg.type() == Message::Type_Error
         || msg.service() != Message::Service_Server

--- a/src/messaging/sessionservice.cpp
+++ b/src/messaging/sessionservice.cpp
@@ -9,6 +9,7 @@
 # pragma warning(disable: 4355)
 #endif
 
+#include <boost/version.hpp>
 #include "sessionservice.hpp"
 #include "servicedirectoryclient.hpp"
 #include "objectregistrar.hpp"
@@ -158,7 +159,11 @@ namespace qi {
       return;
     }
 
+#if BOOST_VERSION < 105800
     const Message& msg = boost::get<const Message&>(data);
+#else
+    const Message& msg = boost::relaxed_get<const Message&>(data);
+#endif
     int function = msg.function();
     bool failure = msg.type() == Message::Type_Error
         || msg.service() != Message::Service_Server


### PR DESCRIPTION
This allows to compile libqi on Ubuntu 16.04.

Two issues:
- bind overloading rules
- strict type checking in boost::get()

1.58 introduces strict type checking in boost::get(). Use relaxed_get()
to get the old behavior. relaxed_get() didn't exist in older versions
of Boost, so the code must check BOOST_VERSION.

Closes #14
